### PR TITLE
Sincronizar enlaces de la tercera oleada

### DIFF
--- a/.github/trigger-third-wave-sync-pr
+++ b/.github/trigger-third-wave-sync-pr
@@ -1,0 +1,2 @@
+triggered_at=2026-08-06T22:53:00+02:00
+scope=third-wave-links-navigation-wiki


### PR DESCRIPTION
Cerrado sin fusión: la sincronización se aplicó directamente sobre `main` y la maquinaria temporal fue retirada.