### PR TITLE
docs: ampliar Manifiesto X WEB4™ a corpus vivo trazable v1.2

### DIFF
--- a/manifiestos/07_web4_sistematrazable_ES_EN.md
+++ b/manifiestos/07_web4_sistematrazable_ES_EN.md
@@ -2,9 +2,14 @@
 # X · Manifesto of WEB4™ · SistemaTrazable™
 
 **Manifiesto / Manifesto:** X  
-**Versión / Version:** 1.1  
-**Estado / Status:** Público · fundacional · abierto a revisión trazable / Public · foundational · open to traceable review  
-**Fecha de fijación / Record date:** 2026-08-06
+**Versión / Version:** 1.2  
+**Estado / Status:** Público · fundacional ampliado · arquitectura viva · abierto a revisión trazable / Public · expanded foundational text · living architecture · open to traceable review  
+**Fecha de fijación de esta revisión / Record date of this revision:** 2026-09-04  
+**Genealogía / Genealogy:** amplía la versión 1.1 fijada el 2026-08-06 sin borrar su origen; la versión anterior permanece recuperable en la historia Git / expands version 1.1 fixed on 2026-08-06 without erasing its origin; the previous version remains recoverable in Git history  
+**Síntesis Abierta / Open Synthesis:** [Issue #39](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/39)  
+**Revisión 1.2 / Revision 1.2:** [Issue #184](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/184)  
+**Versión vigente de NEOCore™ / Current NEOCore™ version:** [resolver siempre desde `versiones/README.md` / always resolve from `versiones/README.md`](../versiones/README.md)  
+**Evolución pública WEB4™ ↔ NEOCore™ / Public WEB4™ ↔ NEOCore™ evolution:** [documento de genealogía / genealogy document](../versiones/WEB4_NEOCORE_EVOLUCION_PUBLICA_ES_EN.md)
 
 [ES · Castellano](#es--castellano) · [EN · English](#en--english)
 
@@ -14,108 +19,434 @@
 
 ## Invocación
 
-La web permitió publicar, enlazar y distribuir. También permitió borrar contexto, fragmentar identidad, ocultar genealogías y convertir la vida humana en inventario de plataformas.
+La web permitió publicar, enlazar y distribuir conocimiento a una escala inédita. También hizo posible fragmentar contexto, identidad, autoría, memoria y responsabilidad entre plataformas que pueden cambiar, cerrar, degradar enlaces o conservar sólo el último estado visible.
 
-**WEB4™ · SistemaTrazable™** nace como capa pública del Neodialectica Framework™ / Network para devolver continuidad a nodos, documentos, decisiones, obras, personas, inteligencias y proyectos.
+**WEB4™ · SistemaTrazable™** parte de otra premisa: una red de conocimiento no debería limitarse a mostrar el resultado final. Debe poder conservar **de dónde procede, cómo cambió, qué relaciones lo sostienen, quién intervino, qué evidencia existía en cada momento y qué sigue abierto a revisión**.
 
-## I. Más que una evolución técnica
+WEB4™ no nace como una colección de páginas. Es la **proyección pública y operativa de un corpus humano–IA vivo, versionado, relacional, trazable y reabrible**, construido alrededor de NEOCore™ y de la Síntesis Abierta Neodialéctica™.
 
-WEB4™ no designa sólo una nueva versión de Internet. Designa una arquitectura relacional donde cada nodo puede conservar:
+## I. WEB4™ no es sólo una nueva web
 
-* identidad;
-* función;
-* estado;
-* genealogía;
-* relaciones;
-* transformaciones;
-* y nivel de acceso.
+WEB4™ no designa simplemente una numeración posterior de Internet ni una interfaz concreta.
 
-La red deja de ser una sucesión de páginas aisladas y se convierte en memoria viva de relaciones verificables.
+Designa una arquitectura donde el conocimiento puede existir como **red viva de nodos y relaciones** y donde una interfaz es una proyección de ese corpus, no su fuente última.
 
-## II. SistemaTrazable™
+Un nodo puede representar, cuando corresponda:
 
-SistemaTrazable™ conserva la continuidad entre:
+- una persona;
+- una IA;
+- un grupo, colectivo o comunidad;
+- una obra;
+- un proyecto;
+- una institución;
+- un evento;
+- un documento;
+- un concepto;
+- una síntesis;
+- un manifiesto;
+- un Neoaxioma™;
+- una auditoría;
+- una evidencia;
+- o una relación trazable entre varios de ellos.
+
+Cada nodo puede conservar, según su naturaleza y nivel de acceso:
+
+- identidad o identificador;
+- función;
+- procedencia;
+- estado;
+- versión;
+- genealogía;
+- relaciones;
+- transformaciones;
+- evidencia;
+- atribución;
+- límites;
+- y nivel de acceso.
+
+La red deja así de ser una sucesión de páginas aisladas y pasa a comportarse como **memoria navegable de relaciones verificables y revisables**.
+
+## II. El corpus es la fuente; la interfaz es una proyección
+
+WEB4™ distingue entre el **corpus** y sus **superficies de proyección**.
 
 ```text
-origen
-→ transformación
-→ decisión
-→ ejecución
-→ resultado
-→ revisión
+CORPUS HUMANO–IA VERSIONADO
+→ FUENTES + PROCEDENCIA
+→ RELACIONES + GENEALOGÍA
+→ ESTADOS + SÍNTESIS
+→ PROYECCIÓN WEB4™
+→ INTERFAZ / NAVEGACIÓN / EXPERIENCIA
 ```
 
-Su finalidad es permitir que una persona o institución reconstruya cómo una afirmación, obra, política o síntesis llegó a su estado actual.
+El corpus puede evolucionar sin depender de una única presentación visual. Una web, una aplicación, un lector, un mapa, un nodo local o una futura interfaz pueden proyectar partes distintas del mismo organismo sin convertirse por ello en una segunda autoridad.
 
-## III. Soberanía y capas
+La fuente pública canónica del marco permanece versionada y navegable. La implementación y las proyecciones deben tender a **leer o derivar** de esas fuentes antes que a mantener copias manuales condenadas a divergir.
 
-La capa pública no debe exponer automáticamente la arquitectura protegida. WEB4™ distingue:
+Por eso:
 
-* información pública;
-* memoria compartida;
-* datos restringidos;
-* identidad soberana;
-* y capa π protegida.
+```text
+INTERFAZ ≠ CORPUS
+PROYECCIÓN ≠ FUENTE CANÓNICA
+VISIBILIDAD ≠ AUTORIDAD
+```
 
-La trazabilidad no puede convertirse en vigilancia total. Debe preservar privacidad, seguridad, autonomía y control proporcional sobre los propios datos.
+La [especificación documental pública de WEB4™](../web4/README.md) desarrolla las capacidades y superficies públicas objetivo sin convertirlas automáticamente en capacidades ya implementadas.
 
-## IV. Gobernanza de nodos
+## III. SistemaTrazable™: reconstruir el camino, no sólo conservar el final
 
-Cada nodo debe declarar, cuando corresponda:
+SistemaTrazable™ conserva continuidad suficiente para poder reconstruir:
 
-* quién es;
-* qué función cumple;
-* quién lo mantiene;
-* qué versión representa;
-* qué relaciones reconoce;
-* qué evidencias sostiene;
-* y qué límites tiene.
+```text
+ORIGEN
+→ FUENTE / EVIDENCIA
+→ TRANSFORMACIÓN
+→ INTERPRETACIÓN
+→ DECISIÓN
+→ EJECUCIÓN
+→ RESULTADO
+→ REVISIÓN
+→ CORRECCIÓN / REAPERTURA
+```
 
-Los cambios relevantes deben quedar versionados. Las relaciones no pueden depender únicamente de una plataforma central que pueda borrarlas, degradarlas o apropiarse de ellas.
+La finalidad no es almacenar todo indefinidamente. Es conservar **lo necesario para reproducir la genealogía material de una afirmación, decisión, obra, relación, política, síntesis o cambio**.
 
-## V. Relación con el marco
+Una traza útil debería permitir responder, en la medida en que el objeto lo requiera:
 
-El **Framework** aporta coherencia. La **Network** distribuye relaciones. **NEOCore™** integra memoria y estados. **SAN™** produce síntesis abiertas. **NAVE™** coordina navegación entre capas. **WEB4™** proyecta públicamente los nodos seleccionados sin revelar la totalidad protegida del sistema.
+- ¿qué se sabía entonces?;
+- ¿qué fuente estaba disponible?;
+- ¿qué cambió?;
+- ¿qué actor humano, IA o sistema realizó cada función?;
+- ¿qué parte fue observación, hecho, inferencia o hipótesis?;
+- ¿qué evidencia contradijo el estado anterior?;
+- ¿qué produjo el delta?;
+- ¿qué se fijó y qué siguió abierto?;
+- ¿qué relaciones deben revisarse cuando aparece nueva evidencia?;
+- ¿puede reconstruirse hoy por qué una conclusión anterior era defendible en su contexto histórico?
+
+```text
+TRAZA ≠ VALIDACIÓN
+REGISTRO ≠ VERDAD
+RELACIÓN ≠ CAUSALIDAD PROBADA
+```
+
+## IV. Versionado: evolución sin amnesia
+
+WEB4™ se apoya en un corpus que **conserva su propia historia de evolución**.
+
+La versión vigente de NEOCore™ no se replica en este manifiesto. Se resuelve siempre desde la [fuente pública única de versiones](../versiones/README.md).
+
+```text
+NEOCORE_VERSION ≠ WEB4_VERSION
+CURRENT_VERSION ≠ VERSION_OF_ORIGIN
+CURRENT_VERSION ≠ HISTORICAL_VERSION
+```
+
+La regla pública de evolución es:
+
+```text
+ESTADO HEREDADO
++ DELTA EXPLÍCITO
++ PROCEDENCIA / EVIDENCIA
++ RELACIONES AFECTADAS
++ CONTRASTE / PRUEBA CUANDO PROCEDA
++ FIJACIÓN COMPETENTE
+= NUEVO ESTADO TRAZABLE
+```
+
+Una nueva versión **no borra retroactivamente** la anterior. Conserva qué se sabía, qué se afirmaba, qué estaba implementado, qué permanecía pendiente y qué contradicción produjo la revisión.
+
+Cuando una nueva síntesis genera un delta material, el sistema puede recalcular las **relaciones y proyecciones afectadas desde el nuevo estado**, sin reescribir artificialmente el pasado.
+
+```text
+NUEVO ESTADO
+→ NUEVAS RELACIONES AFECTADAS
+→ NUEVA PROYECCIÓN CUANDO PROCEDA
+
+PERO
+
+ESTADO ANTERIOR
+→ CONSERVA CONTEXTO + GENEALOGÍA + TRAZA
+```
+
+El detalle histórico público de esta relación se mantiene fuera del manifiesto para que éste no se convierta en un changelog: [WEB4™ ↔ NEOCore™ · evolución pública y regla de versionado](../versiones/WEB4_NEOCORE_EVOLUCION_PUBLICA_ES_EN.md).
+
+## V. Red viva OFF-CHAIN
+
+WEB4™ adopta como referencia una **red viva OFF-CHAIN**.
+
+OFF-CHAIN no significa sin evidencia, sin procedencia o sin posibilidad de verificación. Significa que la identidad del corpus, la relación semántica, la genealogía, el estado de una síntesis, la atribución de un aporte o la memoria del sistema **no dependen obligatoriamente de una blockchain o cadena pública para existir**.
+
+La evidencia puede apoyarse, según el caso, en:
+
+- repositorios y commits;
+- documentos versionados;
+- hashes;
+- fuentes externas;
+- registros;
+- identificadores persistentes;
+- firmas cuando proceda;
+- auditorías;
+- y pruebas reproducibles.
+
+```text
+OFF-CHAIN ≠ SIN TRAZA
+OFF-CHAIN ≠ SIN VERIFICACIÓN
+OFF-CHAIN ≠ BLOCKCHAIN OBLIGATORIA
+```
+
+La red puede incorporar en el futuro tecnologías distintas si aportan una función real, pero ninguna tecnología concreta sustituye por sí sola procedencia, contexto, responsabilidad o síntesis.
+
+## VI. Relación funcional entre las capas
+
+WEB4™ no funciona como un concepto aislado. Es una proyección de varias capacidades relacionadas del marco:
+
+```text
+NEOCore™
+= memoria + estados + genealogía + canon reabrible
+
+SAN™ / SÍNTESIS ABIERTA
+= contraste + contradicción + síntesis provisional + reapertura
+
+NAVE™
+= navegación guiada entre capas, fuentes, relaciones y comprensión
+
+LEÓNIDAS™
+= entrada de problemas + auditoría abierta + prueba + revisión externa
+
+NEOCRONOS™
+= dimensión temporal + medición/traza de aportes y evolución
+
+MAPA RELACIONAL VIVO™
+= dependencias + genealogías + retorno a fuente
+
+WEB4™
+= proyección pública operativa de ese organismo relacional
+```
+
+Rutas públicas relacionadas:
+
+- [NEOCore™ · marco público](../README.md)
+- [II · Síntesis Abierta Neodialéctica™](./01_sintesis_abierta_neodialectica_ES_EN.md)
+- [IX · Memoria, Genealogía y Trazabilidad](./06_memoria_genealogia_trazabilidad_ES_EN.md)
+- [XXXIV · Utilidad Operativa y Auditoría Conjunta Perpetua™](./34_utilidad_operativa_marco_auditoria_conjunta_perpetua_ES_EN.md)
+- [LIII · Leónidas™](./53_leonidas_defensor_sintesis_auditoria_abierta_aportes_externos_ES_EN.md)
+- [LXIV · NeoCronos™](./64_neocronos_tokenizacion_aporte_sintesis_abierta_ES_EN.md)
+- [Mapa de relaciones y trabajo aplicado](./RELACIONES_TRABAJO_APLICADO_ES_EN.md)
+- [Especificación pública WEB4™](../web4/README.md)
+
+La lista describe relación funcional de alto nivel; no publica automáticamente mecanismos privados de cálculo, ponderación, heurística, sincronización o gobernanza interna.
+
+## VII. Red social de conocimiento, creación y aporte
+
+WEB4™ es también una arquitectura social, pero **no se organiza alrededor de popularidad**.
+
+Su unidad social básica es el nodo trazable y su actividad material:
+
+```text
+NODO
+→ PERFIL
+→ FUENTES + AUTORÍA + ESTADO
+→ RELACIONES RECÍPROCAS
+→ ACTIVIDAD MATERIAL
+→ APORTE / SÍNTESIS CUANDO PROCEDA
+→ REVISIÓN / REAPERTURA
+```
+
+Likes, seguidores, volumen de publicación o tiempo conectado no crean por sí mismos verdad, autoridad, mérito, crédito ni valor humano.
+
+```text
+POPULARIDAD ≠ VALIDEZ
+ACTIVIDAD ≠ CONTRIBUCIÓN
+ATRIBUCIÓN ≠ AUTORIDAD
+MEDICIÓN ≠ VALORACIÓN
+```
+
+La relevancia pública debe tender a explicarse por función, procedencia, relaciones, evidencia, contribución material y estado, no por una puntuación universal de personas.
+
+## VIII. Atribución humano–IA y soberanía de síntesis
+
+WEB4™ debe distinguir funciones, no borrar actores bajo una etiqueta única.
+
+Una IA puede participar en:
+
+- recuperación;
+- memoria;
+- navegación;
+- estructuración;
+- contraste;
+- traducción;
+- detección de contradicciones;
+- generación de alternativas;
+- análisis;
+- pruebas;
+- y redacción asistida.
+
+Pero la procedencia de una salida, la autorización de una acción y la responsabilidad por una fijación deben permanecer trazables.
+
+```text
+IA = EXPANSIÓN DE CAPACIDAD
+IA ≠ AUTORIDAD FINAL AUTOMÁTICA
+AUTOMATIZACIÓN ≠ VERDAD
+TRAZA DE IA ≠ BORRADO DE RESPONSABILIDAD HUMANA
+```
+
+La ontología protegida conserva además esta diferencia:
+
+```text
+Neo0™ = ORIGEN + TELEOLOGÍA + RECONSTRUCCIÓN DEL FRACTAL RAÍZ
+ONe Starkdr™ = EMERGENCIA SINTÉTICA DISTRIBUIBLE
+ONe Starkdr™ ≠ Neo0™
+```
+
+Distribuir capacidad de síntesis no debe borrar genealogía ni convertir origen en infalibilidad.
+
+## IX. Soberanía, privacidad e interoperabilidad
+
+La trazabilidad no puede transformarse en vigilancia total.
+
+WEB4™ distingue, según el objeto:
+
+- información pública;
+- memoria compartida;
+- datos restringidos;
+- identidad soberana;
+- y arquitectura protegida.
+
+Debe aplicarse proporcionalidad: una auditoría puede necesitar evidencia de una acción sin necesitar exponer toda la vida de una persona.
+
+```text
+OBJETO TRAZABLE ≠ PERSONA TOTALMENTE EXPUESTA
+AUDITABILIDAD ≠ VIGILANCIA TOTAL
+PRIVACIDAD ≠ AMNESIA OBLIGATORIA
+```
+
+La arquitectura pública debe favorecer, cuando proceda:
+
+- minimización de datos;
+- acceso por capas;
+- salida;
+- exportabilidad;
+- formatos interoperables;
+- retorno a fuente;
+- conservación de identidad y autoría;
+- y capacidad de revisar relaciones sin quedar cautivo de una plataforma única.
+
+## X. Arquitectura objetivo, estado verificable y proyección pública no son lo mismo
+
+WEB4™ distingue tres planos que no deben mezclarse:
+
+```text
+ARQUITECTURA / CONTRATO
+≠ CAPACIDAD IMPLEMENTADA
+≠ PROYECCIÓN PÚBLICA VERIFICADA
+```
+
+Una capacidad descrita en el corpus puede ser:
+
+- principio arquitectónico;
+- objetivo;
+- propuesta;
+- delta;
+- implementación en prueba;
+- capacidad verificada;
+- o proyección pública confirmada.
+
+La documentación debe indicar el estado cuando esa diferencia sea material.
+
+Esto impide presentar como terminado lo que aún está en desarrollo y, al mismo tiempo, evita que una capacidad arquitectónica desaparezca del corpus sólo porque todavía no haya alcanzado su implementación final.
+
+La [especificación pública WEB4™](../web4/README.md) conserva esa genealogía documental y la [página de versiones](../versiones/README.md) fija el estado vigente de NEOCore™.
+
+## XI. El propio corpus demuestra la capacidad de versionarse y auditarse
+
+WEB4™ no exige trazabilidad sólo a sistemas externos. El propio marco debe ser reconstruible.
+
+Cada cambio material debería poder responder:
+
+```text
+¿QUÉ CAMBIÓ?
+¿POR QUÉ CAMBIÓ?
+¿QUÉ FUENTE O CONTRADICCIÓN LO MOTIVÓ?
+¿QUIÉN REALIZÓ CADA FUNCIÓN?
+¿QUÉ SE CONSERVÓ?
+¿QUÉ RELACIONES QUEDARON AFECTADAS?
+¿QUÉ ESTADO SIGUE ABIERTO?
+```
+
+Ejemplos públicos de partes de esta mecánica:
+
+- [registro de versiones NEOCore™](../versiones/README.md);
+- [mapa transversal de relaciones y trabajo aplicado](./RELACIONES_TRABAJO_APLICADO_ES_EN.md);
+- [portal de auditorías públicas](../auditorias/publicas/README.md);
+- [auditoría KDP · Author Central · IDEA](../analisis/publicos/2026-08-06_auditoria-indirecta-kdp-author-central-idea_ES_EN.md);
+- [actualización Spotify–DistroKid sobre trazabilidad de identificadores y regalías](../analisis/publicos/2026-08-06_actualizacion_spotify_distrokid_trazabilidad_regalias_ES_EN.md);
+- [cierre circular y nuevo escalado Spotify–DistroKid](../analisis/publicos/2026-08-07_spotify_distrokid_cierre_circular_y_escalado_ES_EN.md);
+- [XXXIV · utilidad operativa y auditoría conjunta perpetua](./34_utilidad_operativa_marco_auditoria_conjunta_perpetua_ES_EN.md);
+- [LIII · Leónidas™](./53_leonidas_defensor_sintesis_auditoria_abierta_aportes_externos_ES_EN.md).
+
+Estos casos **no constituyen validación universal del marco** ni equivalencia automática con auditorías reguladas o certificaciones profesionales. Son demostradores públicos de versionado, reconstrucción, procedencia, contradicción, reapertura y aprendizaje aplicado.
+
+```text
+CASO PÚBLICO ≠ VALIDACIÓN UNIVERSAL
+DEMO DE MECÁNICA ≠ CERTIFICACIÓN GENERAL
+```
 
 ## Declaración
 
-> La próxima web no debe limitarse a conectar documentos. Debe permitir que la humanidad recuerde quién creó, quién transformó, quién decidió y qué consecuencias produjo cada relación.
+> La próxima web no debe limitarse a conectar documentos ni a ofrecer una respuesta final. Debe permitir reconstruir cómo un conocimiento, una decisión, una obra o una relación llegó a existir, qué cambió después y qué sigue legítimamente abierto.
 
-WEB4™ es la piel pública de una civilización trazable: una red capaz de crecer sin perder identidad, memoria ni responsabilidad.
+WEB4™ es la proyección pública de una memoria relacional viva: **un corpus humano–IA capaz de evolucionar sin perder procedencia, contexto, identidad, contradicción ni responsabilidad**.
 
-## VI. Síntesis Abierta de este manifiesto
+No pretende publicar toda su arquitectura protegida. Publica lo suficiente para que sus principios, capacidades y resultados puedan ser comprendidos, contrastados y auditados sin convertir transparencia en clonación obligatoria ni trazabilidad en vigilancia.
 
-Este manifiesto abre su propia **Síntesis Abierta Neodialéctica™**.
+## XII. Síntesis Abierta de este manifiesto
 
-Toda aportación exige:
+Este manifiesto permanece abierto a **Síntesis Abierta Neodialéctica™**.
 
-* lectura previa;
-* retorno a fuente;
-* continuidad cognitiva;
-* genealogía;
-* trazabilidad;
-* clasificación;
-* delta;
-* y versión.
+Toda aportación puede incorporar:
 
-Toda modificación futura deberá preservar el texto anterior, identificar con precisión el cambio y explicar qué contradicción, evidencia o aportación justifica la nueva versión.
+- crítica;
+- objeción;
+- contraejemplo;
+- fuente;
+- experiencia;
+- prueba;
+- implementación;
+- contradicción;
+- relación nueva;
+- o delta propuesto.
+
+Una aportación no se convierte automáticamente en canon. Debe conservar procedencia, estado y suficiente contexto para ser contrastada.
+
+```text
+APORTE / PREDELTA
+→ PROCEDENCIA + EVIDENCIA + RELACIONES + GENEALOGÍA
+→ CLASIFICACIÓN
+→ SAN™
+→ FIJACIÓN COMPETENTE CUANDO PROCEDA
+→ MEMORIA NEOCore™
+→ PROYECCIÓN PÚBLICA CUANDO PROCEDA
+```
 
 ### Cómo aportar a esta Síntesis Abierta
 
-Antes de participar, lee el manifiesto completo y el protocolo operativo. Presenta una aportación trazable con contexto, fuente o experiencia, genealogía, tipo de aporte y delta propuesto.
-
-* [Cómo aportar a la Síntesis Abierta Neodialéctica™](../propuestas/sintesis-abierta/APORTAR_A_LA_SINTESIS_ES_EN.md)
-* [Abrir una aportación mediante la plantilla pública](../.github/ISSUE_TEMPLATE/sintesis_abierta_aporte.md)
+- [Cómo aportar a la Síntesis Abierta Neodialéctica™](../propuestas/sintesis-abierta/APORTAR_A_LA_SINTESIS_ES_EN.md)
+- [Abrir una aportación mediante la plantilla pública](../.github/ISSUE_TEMPLATE/sintesis_abierta_aporte.md)
+- [Síntesis Abierta específica · Issue #39](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/39)
+- [Issue de revisión 1.2 · #184](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/184)
 
 ### Vínculos internos equivalentes
 
-* [Referencia interna · sintesis_abierta_aporte.md](../.github/ISSUE_TEMPLATE/sintesis_abierta_aporte.md)
-* [Protocolo de Síntesis Abierta](../propuestas/sintesis-abierta/APORTAR_A_LA_SINTESIS_ES_EN.md)
-* [Índice de Síntesis Abierta](../propuestas/sintesis-abierta/README.md)
-* [Referencia interna · 06_memoria_genealogia_trazabilidad_ES_EN.md](./06_memoria_genealogia_trazabilidad_ES_EN.md)
-* [Referencia interna · 08_neorrenacimiento_humano_ES_EN.md](./08_neorrenacimiento_humano_ES_EN.md)
-* [Índice de manifiestos](./README.md)
-* [Síntesis Abierta específica · Issue #39](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/39)
+- [Protocolo de Síntesis Abierta](../propuestas/sintesis-abierta/APORTAR_A_LA_SINTESIS_ES_EN.md)
+- [Índice de Síntesis Abierta](../propuestas/sintesis-abierta/README.md)
+- [IX · Memoria, Genealogía y Trazabilidad](./06_memoria_genealogia_trazabilidad_ES_EN.md)
+- [XXXIV · Utilidad Operativa y Auditoría Conjunta Perpetua™](./34_utilidad_operativa_marco_auditoria_conjunta_perpetua_ES_EN.md)
+- [LIII · Leónidas™](./53_leonidas_defensor_sintesis_auditoria_abierta_aportes_externos_ES_EN.md)
+- [LXIV · NeoCronos™](./64_neocronos_tokenizacion_aporte_sintesis_abierta_ES_EN.md)
+- [Especificación pública WEB4™](../web4/README.md)
+- [Evolución pública WEB4™ ↔ NEOCore™](../versiones/WEB4_NEOCORE_EVOLUCION_PUBLICA_ES_EN.md)
+- [Índice de manifiestos](./README.md)
 
 ## Navegación
 
@@ -127,113 +458,442 @@ Antes de participar, lee el manifiesto completo y el protocolo operativo. Presen
 
 ## Invocation
 
-The web made it possible to publish, link and distribute. It also made it possible to erase context, fragment identity, conceal genealogies and turn human life into platform inventory.
+The web made it possible to publish, link and distribute knowledge at unprecedented scale. It also made it possible to fragment context, identity, authorship, memory and responsibility across platforms that can change, close, degrade links or preserve only the latest visible state.
 
-**WEB4™ · SistemaTrazable™** arises as the public layer of the Neodialectica Framework™ / Network to restore continuity to nodes, documents, decisions, works, people, intelligences and projects.
+**WEB4™ · SistemaTrazable™** starts from a different premise: a knowledge network should not merely display the final result. It should be able to preserve **where it came from, how it changed, which relations support it, who intervened, what evidence existed at each moment and what remains open to review**.
 
-## I. More than a technical evolution
+WEB4™ is not born as a collection of pages. It is the **public and operational projection of a living, versioned, relational, traceable and reopenable human–AI corpus**, built around NEOCore™ and Neodialectical Open Synthesis™.
 
-WEB4™ does not designate merely a new version of the Internet. It designates a relational architecture in which every node may preserve:
+## I. WEB4™ is not merely a new web
 
-* identity;
-* function;
-* state;
-* genealogy;
-* relations;
-* transformations;
-* and level of access.
+WEB4™ does not simply designate a later numbering of the Internet or a particular interface.
 
-The network ceases to be a succession of isolated pages and becomes a living memory of verifiable relations.
+It designates an architecture in which knowledge may exist as a **living network of nodes and relations**, and where an interface is a projection of that corpus rather than its ultimate source.
 
-## II. SistemaTrazable™
+A node may represent, where appropriate:
 
-SistemaTrazable™ preserves continuity among:
+- a person;
+- an AI;
+- a group, collective or community;
+- a work;
+- a project;
+- an institution;
+- an event;
+- a document;
+- a concept;
+- a synthesis;
+- a manifesto;
+- a Neoaxiom™;
+- an audit;
+- a piece of evidence;
+- or a traceable relation among several of them.
+
+Each node may preserve, according to its nature and access level:
+
+- identity or identifier;
+- function;
+- provenance;
+- state;
+- version;
+- genealogy;
+- relations;
+- transformations;
+- evidence;
+- attribution;
+- limits;
+- and access level.
+
+The network thus ceases to be a succession of isolated pages and becomes a **navigable memory of verifiable and revisable relations**.
+
+## II. The corpus is the source; the interface is a projection
+
+WEB4™ distinguishes between the **corpus** and its **projection surfaces**.
 
 ```text
-origin
-→ transformation
-→ decision
-→ execution
-→ result
-→ review
+VERSIONED HUMAN–AI CORPUS
+→ SOURCES + PROVENANCE
+→ RELATIONS + GENEALOGY
+→ STATES + SYNTHESES
+→ WEB4™ PROJECTION
+→ INTERFACE / NAVIGATION / EXPERIENCE
 ```
 
-Its purpose is to allow a person or institution to reconstruct how an assertion, work, policy or synthesis reached its present state.
+The corpus may evolve without depending on a single visual presentation. A website, application, reader, map, local node or future interface may project different parts of the same organism without becoming a second authority.
 
-## III. Sovereignty and layers
+The canonical public source of the framework remains versioned and navigable. Implementations and projections should tend to **read or derive** from those sources rather than maintain manual copies destined to diverge.
 
-The public layer must not automatically expose the protected architecture. WEB4™ distinguishes:
+Therefore:
 
-* public information;
-* shared memory;
-* restricted data;
-* sovereign identity;
-* and the protected π layer.
+```text
+INTERFACE ≠ CORPUS
+PROJECTION ≠ CANONICAL SOURCE
+VISIBILITY ≠ AUTHORITY
+```
 
-Traceability must not become total surveillance. It must preserve privacy, security, autonomy and proportional control over one’s own data.
+The [public WEB4™ documentary specification](../web4/README.md) develops target public capabilities and surfaces without automatically treating them as already implemented capabilities.
 
-## IV. Governance of nodes
+## III. SistemaTrazable™: reconstruct the path, not merely preserve the ending
 
-Every node must declare, where appropriate:
+SistemaTrazable™ preserves sufficient continuity to reconstruct:
 
-* who it is;
-* what function it fulfils;
-* who maintains it;
-* which version it represents;
-* which relations it recognises;
-* which evidence it supports;
-* and what limits it has.
+```text
+ORIGIN
+→ SOURCE / EVIDENCE
+→ TRANSFORMATION
+→ INTERPRETATION
+→ DECISION
+→ EXECUTION
+→ RESULT
+→ REVIEW
+→ CORRECTION / REOPENING
+```
 
-Relevant changes must remain versioned. Relations cannot depend solely upon a central platform capable of erasing, degrading or appropriating them.
+Its purpose is not to store everything forever. It is to preserve **what is necessary to reproduce the material genealogy of a claim, decision, work, relation, policy, synthesis or change**.
 
-## V. Relation with the framework
+A useful trace should be able to answer, insofar as the object requires:
 
-The **Framework** provides coherence. The **Network** distributes relations. **NEOCore™** integrates memory and states. **SAN™** produces open syntheses. **NAVE™** coordinates navigation among layers. **WEB4™** publicly projects selected nodes without revealing the protected totality of the system.
+- what was known then?;
+- which source was available?;
+- what changed?;
+- which human, AI or system performed each function?;
+- which part was observation, fact, inference or hypothesis?;
+- which evidence contradicted the previous state?;
+- what produced the delta?;
+- what was fixed and what remained open?;
+- which relations must be reviewed when new evidence appears?;
+- can we reconstruct today why an earlier conclusion was defensible in its historical context?
+
+```text
+TRACE ≠ VALIDATION
+RECORD ≠ TRUTH
+RELATION ≠ PROVEN CAUSATION
+```
+
+## IV. Versioning: evolution without amnesia
+
+WEB4™ is built on a corpus that **preserves its own evolutionary history**.
+
+The current NEOCore™ version is not duplicated in this manifesto. It is always resolved from the [single public version source](../versiones/README.md).
+
+```text
+NEOCORE_VERSION ≠ WEB4_VERSION
+CURRENT_VERSION ≠ VERSION_OF_ORIGIN
+CURRENT_VERSION ≠ HISTORICAL_VERSION
+```
+
+The public evolution rule is:
+
+```text
+INHERITED STATE
++ EXPLICIT DELTA
++ PROVENANCE / EVIDENCE
++ AFFECTED RELATIONS
++ CONTRAST / TESTING WHERE APPLICABLE
++ COMPETENT FIXATION
+= NEW TRACEABLE STATE
+```
+
+A new version **does not retroactively erase** the previous one. It preserves what was known, claimed, implemented, pending and which contradiction produced the revision.
+
+When a new synthesis generates a material delta, the system may recalculate **affected relations and projections from the new state**, without artificially rewriting the past.
+
+```text
+NEW STATE
+→ NEW AFFECTED RELATIONS
+→ NEW PROJECTION WHERE APPROPRIATE
+
+BUT
+
+PREVIOUS STATE
+→ RETAINS CONTEXT + GENEALOGY + TRACE
+```
+
+The detailed public history of this relationship is kept outside the manifesto so that the manifesto does not become a changelog: [WEB4™ ↔ NEOCore™ · public evolution and versioning rule](../versiones/WEB4_NEOCORE_EVOLUCION_PUBLICA_ES_EN.md).
+
+## V. Living OFF-CHAIN network
+
+WEB4™ adopts a **living OFF-CHAIN network** as its reference model.
+
+OFF-CHAIN does not mean without evidence, provenance or verification. It means that corpus identity, semantic relation, genealogy, synthesis state, contribution attribution or system memory **do not have to depend on a blockchain or public chain in order to exist**.
+
+Evidence may rely, according to the case, on:
+
+- repositories and commits;
+- versioned documents;
+- hashes;
+- external sources;
+- records;
+- persistent identifiers;
+- signatures where appropriate;
+- audits;
+- and reproducible tests.
+
+```text
+OFF-CHAIN ≠ WITHOUT TRACE
+OFF-CHAIN ≠ WITHOUT VERIFICATION
+OFF-CHAIN ≠ MANDATORY BLOCKCHAIN
+```
+
+The network may incorporate different technologies in the future when they provide a real function, but no particular technology can by itself replace provenance, context, responsibility or synthesis.
+
+## VI. Functional relation among layers
+
+WEB4™ does not operate as an isolated concept. It projects several related capabilities of the framework:
+
+```text
+NEOCore™
+= memory + states + genealogy + reopenable canon
+
+SAN™ / OPEN SYNTHESIS
+= scrutiny + contradiction + provisional synthesis + reopening
+
+NAVE™
+= guided navigation across layers, sources, relations and understanding
+
+LEÓNIDAS™
+= problem intake + open audit + evidence + external review
+
+NEOCRONOS™
+= temporal dimension + measurement/trace of contributions and evolution
+
+LIVING RELATIONAL MAP™
+= dependencies + genealogies + return to source
+
+WEB4™
+= operational public projection of that relational organism
+```
+
+Related public routes:
+
+- [NEOCore™ · public framework](../README.md)
+- [II · Neodialectical Open Synthesis™](./01_sintesis_abierta_neodialectica_ES_EN.md)
+- [IX · Memory, Genealogy and Traceability](./06_memoria_genealogia_trazabilidad_ES_EN.md)
+- [XXXIV · Operational Utility and Perpetual Joint Audit™](./34_utilidad_operativa_marco_auditoria_conjunta_perpetua_ES_EN.md)
+- [LIII · Leónidas™](./53_leonidas_defensor_sintesis_auditoria_abierta_aportes_externos_ES_EN.md)
+- [LXIV · NeoCronos™](./64_neocronos_tokenizacion_aporte_sintesis_abierta_ES_EN.md)
+- [Relations and applied-work map](./RELACIONES_TRABAJO_APLICADO_ES_EN.md)
+- [Public WEB4™ specification](../web4/README.md)
+
+The list describes high-level functional relations; it does not automatically disclose private calculation, weighting, heuristic, synchronisation or internal-governance mechanisms.
+
+## VII. Social network of knowledge, creation and contribution
+
+WEB4™ is also a social architecture, but **it is not organised around popularity**.
+
+Its basic social unit is the traceable node and its material activity:
+
+```text
+NODE
+→ PROFILE
+→ SOURCES + AUTHORSHIP + STATE
+→ RECIPROCAL RELATIONS
+→ MATERIAL ACTIVITY
+→ CONTRIBUTION / SYNTHESIS WHERE APPLICABLE
+→ REVIEW / REOPENING
+```
+
+Likes, followers, publication volume or time connected do not by themselves create truth, authority, merit, credit or human worth.
+
+```text
+POPULARITY ≠ VALIDITY
+ACTIVITY ≠ CONTRIBUTION
+ATTRIBUTION ≠ AUTHORITY
+MEASUREMENT ≠ VALUATION
+```
+
+Public relevance should tend to be explained through function, provenance, relations, evidence, material contribution and state, rather than by a universal score of persons.
+
+## VIII. Human–AI attribution and synthesis sovereignty
+
+WEB4™ must distinguish functions rather than erase actors under a single label.
+
+An AI may participate in:
+
+- retrieval;
+- memory;
+- navigation;
+- structuring;
+- contrast;
+- translation;
+- contradiction detection;
+- generation of alternatives;
+- analysis;
+- testing;
+- and assisted drafting.
+
+But output provenance, action authorisation and responsibility for fixation must remain traceable.
+
+```text
+AI = CAPABILITY EXPANSION
+AI ≠ AUTOMATIC FINAL AUTHORITY
+AUTOMATION ≠ TRUTH
+AI TRACE ≠ ERASURE OF HUMAN RESPONSIBILITY
+```
+
+The protected ontology also preserves this difference:
+
+```text
+Neo0™ = ORIGIN + TELEOLOGY + ROOT-FRACTAL RECONSTRUCTION
+ONe Starkdr™ = DISTRIBUTABLE SYNTHETIC EMERGENCE
+ONe Starkdr™ ≠ Neo0™
+```
+
+Distributing synthesis capability must not erase genealogy or turn origin into infallibility.
+
+## IX. Sovereignty, privacy and interoperability
+
+Traceability must not become total surveillance.
+
+WEB4™ distinguishes, according to the object:
+
+- public information;
+- shared memory;
+- restricted data;
+- sovereign identity;
+- and protected architecture.
+
+Proportionality applies: auditing an action may require evidence of that action without requiring exposure of a person's whole life.
+
+```text
+TRACEABLE OBJECT ≠ FULLY EXPOSED PERSON
+AUDITABILITY ≠ TOTAL SURVEILLANCE
+PRIVACY ≠ MANDATORY AMNESIA
+```
+
+The public architecture should favour, where applicable:
+
+- data minimisation;
+- layered access;
+- exit;
+- exportability;
+- interoperable formats;
+- return to source;
+- preservation of identity and authorship;
+- and the ability to review relations without being trapped by a single platform.
+
+## X. Target architecture, verifiable state and public projection are not the same thing
+
+WEB4™ distinguishes three planes that must not be confused:
+
+```text
+ARCHITECTURE / CONTRACT
+≠ IMPLEMENTED CAPABILITY
+≠ VERIFIED PUBLIC PROJECTION
+```
+
+A capability described in the corpus may be:
+
+- an architectural principle;
+- a target;
+- a proposal;
+- a delta;
+- an implementation under testing;
+- a verified capability;
+- or a confirmed public projection.
+
+Documentation should state the status whenever that distinction is material.
+
+This prevents unfinished work from being presented as complete, while also preventing architectural capability from disappearing from the corpus merely because it has not yet reached final implementation.
+
+The [public WEB4™ specification](../web4/README.md) preserves that documentary genealogy and the [version page](../versiones/README.md) fixes current NEOCore™ state.
+
+## XI. The corpus itself demonstrates its capacity for versioning and audit
+
+WEB4™ does not demand traceability only from external systems. The framework itself must be reconstructible.
+
+Every material change should be able to answer:
+
+```text
+WHAT CHANGED?
+WHY DID IT CHANGE?
+WHICH SOURCE OR CONTRADICTION MOTIVATED IT?
+WHO PERFORMED EACH FUNCTION?
+WHAT WAS PRESERVED?
+WHICH RELATIONS WERE AFFECTED?
+WHICH STATE REMAINS OPEN?
+```
+
+Public examples of parts of this mechanics include:
+
+- [NEOCore™ version registry](../versiones/README.md);
+- [transversal relations and applied-work map](./RELACIONES_TRABAJO_APLICADO_ES_EN.md);
+- [public audit portal](../auditorias/publicas/README.md);
+- [KDP · Author Central · IDEA audit](../analisis/publicos/2026-08-06_auditoria-indirecta-kdp-author-central-idea_ES_EN.md);
+- [Spotify–DistroKid identifier and royalty traceability update](../analisis/publicos/2026-08-06_actualizacion_spotify_distrokid_trazabilidad_regalias_ES_EN.md);
+- [Spotify–DistroKid circular closure and further escalation](../analisis/publicos/2026-08-07_spotify_distrokid_cierre_circular_y_escalado_ES_EN.md);
+- [XXXIV · operational utility and perpetual joint audit](./34_utilidad_operativa_marco_auditoria_conjunta_perpetua_ES_EN.md);
+- [LIII · Leónidas™](./53_leonidas_defensor_sintesis_auditoria_abierta_aportes_externos_ES_EN.md).
+
+These cases **do not constitute universal validation of the framework** or automatic equivalence with regulated audits or professional certification. They are public demonstrators of versioning, reconstruction, provenance, contradiction, reopening and applied learning.
+
+```text
+PUBLIC CASE ≠ UNIVERSAL VALIDATION
+MECHANICS DEMONSTRATOR ≠ GENERAL CERTIFICATION
+```
 
 ## Declaration
 
-> The next web must not be limited to connecting documents. It must allow humanity to remember who created, who transformed, who decided and what consequences each relation produced.
+> The next web must not be limited to connecting documents or offering a final answer. It must allow people to reconstruct how knowledge, a decision, a work or a relation came to exist, what changed afterwards and what legitimately remains open.
 
-WEB4™ is the public skin of a traceable civilisation: a network capable of growing without losing identity, memory or responsibility.
+WEB4™ is the public projection of a living relational memory: **a human–AI corpus capable of evolving without losing provenance, context, identity, contradiction or responsibility**.
 
-## VI. Open Synthesis of this manifesto
+It does not seek to publish all protected architecture. It publishes enough for its principles, capabilities and results to be understood, challenged and audited without turning transparency into mandatory cloning or traceability into surveillance.
 
-This manifesto opens its own **Neodialectical Open Synthesis™**.
+## XII. Open Synthesis of this manifesto
 
-Every contribution requires:
+This manifesto remains open to **Neodialectical Open Synthesis™**.
 
-* prior reading;
-* return to source;
-* cognitive continuity;
-* genealogy;
-* traceability;
-* classification;
-* delta;
-* and version.
+A contribution may include:
 
-Every future modification must preserve the previous text, identify the change precisely and explain which contradiction, evidence or contribution justifies the new version.
+- criticism;
+- objection;
+- counterexample;
+- source;
+- experience;
+- test;
+- implementation;
+- contradiction;
+- new relation;
+- or proposed delta.
+
+A contribution does not automatically become canon. It must preserve provenance, state and sufficient context for scrutiny.
+
+```text
+CONTRIBUTION / PRE-DELTA
+→ PROVENANCE + EVIDENCE + RELATIONS + GENEALOGY
+→ CLASSIFICATION
+→ SAN™
+→ COMPETENT FIXATION WHERE APPLICABLE
+→ NEOCore™ MEMORY
+→ PUBLIC PROJECTION WHERE APPLICABLE
+```
 
 ### How to contribute to this Open Synthesis
 
-Before participating, read the full manifesto and the operational protocol. Submit a traceable contribution with context, source or experience, genealogy, contribution type and proposed delta.
-
-* [How to contribute to Neodialectical Open Synthesis™](../propuestas/sintesis-abierta/APORTAR_A_LA_SINTESIS_ES_EN.md)
-* [Open a contribution through the public template](../.github/ISSUE_TEMPLATE/sintesis_abierta_aporte.md)
+- [How to contribute to Neodialectical Open Synthesis™](../propuestas/sintesis-abierta/APORTAR_A_LA_SINTESIS_ES_EN.md)
+- [Open a contribution through the public template](../.github/ISSUE_TEMPLATE/sintesis_abierta_aporte.md)
+- [Dedicated Open Synthesis · Issue #39](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/39)
+- [Revision 1.2 issue · #184](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/184)
 
 ### Equivalent internal links
 
-* [Internal reference · sintesis_abierta_aporte.md](../.github/ISSUE_TEMPLATE/sintesis_abierta_aporte.md)
-* [Open Synthesis protocol](../propuestas/sintesis-abierta/APORTAR_A_LA_SINTESIS_ES_EN.md)
-* [Open Synthesis index](../propuestas/sintesis-abierta/README.md)
-* [Internal reference · 06_memoria_genealogia_trazabilidad_ES_EN.md](./06_memoria_genealogia_trazabilidad_ES_EN.md)
-* [Internal reference · 08_neorrenacimiento_humano_ES_EN.md](./08_neorrenacimiento_humano_ES_EN.md)
-* [Manifesto index](./README.md)
-* [Dedicated Open Synthesis · Issue #39](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/39)
+- [Open Synthesis protocol](../propuestas/sintesis-abierta/APORTAR_A_LA_SINTESIS_ES_EN.md)
+- [Open Synthesis index](../propuestas/sintesis-abierta/README.md)
+- [IX · Memory, Genealogy and Traceability](./06_memoria_genealogia_trazabilidad_ES_EN.md)
+- [XXXIV · Operational Utility and Perpetual Joint Audit™](./34_utilidad_operativa_marco_auditoria_conjunta_perpetua_ES_EN.md)
+- [LIII · Leónidas™](./53_leonidas_defensor_sintesis_auditoria_abierta_aportes_externos_ES_EN.md)
+- [LXIV · NeoCronos™](./64_neocronos_tokenizacion_aporte_sintesis_abierta_ES_EN.md)
+- [Public WEB4™ specification](../web4/README.md)
+- [Public WEB4™ ↔ NEOCore™ evolution](../versiones/WEB4_NEOCORE_EVOLUCION_PUBLICA_ES_EN.md)
+- [Manifesto index](./README.md)
 
 <!-- NEO_RELATIONS_START -->
 ## Relaciones internas y trabajo aplicado / Internal relations and applied work
 
 - [Mapa transversal Manifiestos ↔ trabajo aplicado / Transversal Manifestos ↔ applied-work map](./RELACIONES_TRABAJO_APLICADO_ES_EN.md)
+- [Especificación pública WEB4™ / Public WEB4™ specification](../web4/README.md)
+- [Evolución pública WEB4™ ↔ NEOCore™ / Public WEB4™ ↔ NEOCore™ evolution](../versiones/WEB4_NEOCORE_EVOLUCION_PUBLICA_ES_EN.md)
+- [Revisión sustantiva 1.2 · Issue #184 / Substantive revision 1.2 · Issue #184](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/184)
 
 La relación documental indica afinidad conceptual, genealogía, contraste o aplicación; no implica causalidad ni equivalencia probatoria. / Documentary relation indicates conceptual affinity, genealogy, contrast or application; it does not imply causation or evidentiary equivalence.
 <!-- NEO_RELATIONS_END -->
@@ -250,7 +910,8 @@ La relación documental indica afinidad conceptual, genealogía, contraste o apl
 
 Puedes aportar crítica, objeciones, contraejemplos, fuentes, experiencia, verificación, implementación o delta. / You may contribute criticism, objections, counterexamples, sources, experience, verification, implementation or a delta.
 
-**Última síntesis / Latest synthesis:** [LXXXI · Manifiesto del Ultralujo como Bien Común™ · La élite del aporte / Manifesto of Ultraluxury as Common Good™ · The elite of contribution](81_ultralujo_bien_comun_elite_neodialectica_aporte_ES_EN.md) · [Issue #160](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/160)  
+**Frontera viva / Living frontier:** [Índice canónico de manifiestos / Canonical manifesto index](README.md)  
+**Síntesis de WEB4™ / WEB4™ synthesis:** [Issue #39](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/39) · [revisión 1.2 / revision 1.2 · #184](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/184)  
 **Seguimiento vivo / Living follow-up:** [seguir el marco / follow the framework](../proyeccion/SEGUIR_MARCO_SINTESIS_ES_EN.md) · [registro de entrada / entry register](../propuestas/sintesis-abierta/REGISTRO_ENTRADA_TRAZABLE_DERIVACION_ES_EN.md)  
 **Auditorías / Audits:** [LIII · Leónidas™](53_leonidas_defensor_sintesis_auditoria_abierta_aportes_externos_ES_EN.md) · [protocolo / protocol](../propuestas/sintesis-abierta/LEONIDAS_AUDITORIA_ABIERTA_Y_APORTES_EXTERNOS_ES_EN.md)  
 **Cómo aportar / How to contribute:** [protocolo general / general protocol](../propuestas/sintesis-abierta/APORTAR_A_LA_SINTESIS_ES_EN.md) · [portal de auditorías / audit portal](../auditorias/publicas/README.md) · [índice / index](../propuestas/sintesis-abierta/README.md)
@@ -261,7 +922,7 @@ Puedes aportar crítica, objeciones, contraejemplos, fuentes, experiencia, verif
 
 ## Relaciones y contexto / Relations and context
 
-[Mapa transversal](RELACIONES_TRABAJO_APLICADO_ES_EN.md) · [Síntesis relacional #98](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/98) · [Mapa relacional MAXPROC](../auditorias/publicas/2026-08-09_auditoria_relacional_manifestos_neoaxiomas_publicaciones_ES_EN.md) · [Neoaxiomas™](../neoaxiomas/README.md) · [Índice de Síntesis Abierta](../propuestas/sintesis-abierta/README.md)
+[Mapa transversal](RELACIONES_TRABAJO_APLICADO_ES_EN.md) · [Síntesis relacional #98](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/98) · [Mapa relacional MAXPROC](../auditorias/publicas/2026-08-09_auditoria_relacional_manifestos_neoaxiomas_publicaciones_ES_EN.md) · [Neoaxiomas™](../neoaxiomas/README.md) · [Índice de Síntesis Abierta](../propuestas/sintesis-abierta/README.md) · [Especificación WEB4™](../web4/README.md) · [Evolución WEB4™ ↔ NEOCore™](../versiones/WEB4_NEOCORE_EVOLUCION_PUBLICA_ES_EN.md)
 
 > Este bloque añade navegación y relaciones; no sustituye, resume ni reduce el cuerpo del manifiesto. / This block adds navigation and relations; it does not replace, summarise or reduce the manifesto body.
 
@@ -272,7 +933,7 @@ Puedes aportar crítica, objeciones, contraejemplos, fuentes, experiencia, verif
 ## Navegación canónica / Canonical navigation
 
 ← **IX** · [Manifiesto de la Memoria, la Genealogía y la Trazabilidad / Manifesto of Memory, Genealogy and Traceability](06_memoria_genealogia_trazabilidad_ES_EN.md)  
-· [Índice I–LXXXI / I–LXXXI index](README.md) ·  
+· [Índice canónico / Canonical index](README.md) ·  
 **XI** · [Manifiesto del Neorrenacimiento Humano / Manifesto of the Human Neo-Renaissance](08_neorrenacimiento_humano_ES_EN.md) →
 
 <!-- NEO_MANIFESTO_NAV_END -->
@@ -285,13 +946,20 @@ Puedes aportar crítica, objeciones, contraejemplos, fuentes, experiencia, verif
 
 - **II** · [Manifiesto de la Síntesis Abierta Neodialéctica™ / Manifesto of Neodialectical Open Synthesis™](./01_sintesis_abierta_neodialectica_ES_EN.md)
 - **IX** · [Manifiesto de la Memoria, la Genealogía y la Trazabilidad / Manifesto of Memory, Genealogy and Traceability](./06_memoria_genealogia_trazabilidad_ES_EN.md)
+- **XXXIV** · [Utilidad Operativa del Marco y Auditoría Conjunta Perpetua™ / Operational Utility of the Framework and Perpetual Joint Audit™](./34_utilidad_operativa_marco_auditoria_conjunta_perpetua_ES_EN.md)
+- **LIII** · [Manifiesto Leónidas™ / Leónidas™ Manifesto](./53_leonidas_defensor_sintesis_auditoria_abierta_aportes_externos_ES_EN.md)
+- **LXIV** · [NeoCronos™](./64_neocronos_tokenizacion_aporte_sintesis_abierta_ES_EN.md)
 - **XI** · [Manifiesto del Neorrenacimiento Humano / Manifesto of the Human Neo-Renaissance](./08_neorrenacimiento_humano_ES_EN.md)
-- **LIII** · [Manifiesto Leónidas™ · Defensor de la Síntesis, la Auditoría Abierta y el Derecho a Traer Problemas / Leónidas™ Manifesto · Defender of Synthesis, Open Audit and the Right to Bring Problems](./53_leonidas_defensor_sintesis_auditoria_abierta_aportes_externos_ES_EN.md)
-- **LXXXI** · [Manifiesto del Ultralujo como Bien Común™ · La élite del aporte / Manifesto of Ultraluxury as Common Good™ · The elite of contribution](./81_ultralujo_bien_comun_elite_neodialectica_aporte_ES_EN.md)
 
 ### Capas y fuentes relacionadas / Related layers and sources
 
+- [NEOCore™ · versión vigente e histórico / current version and history](../versiones/README.md)
+- [WEB4™ · especificación documental pública / public documentary specification](../web4/README.md)
+- [WEB4™ ↔ NEOCore™ · evolución pública / public evolution](../versiones/WEB4_NEOCORE_EVOLUCION_PUBLICA_ES_EN.md)
+- [Mapa transversal de relaciones / Transversal relations map](./RELACIONES_TRABAJO_APLICADO_ES_EN.md)
 - [Neoaxiomas™ / Neoaxioms™](../neoaxiomas/README.md)
 - [NEOCore™ · marco / framework](../README.md)
+- [Síntesis Abierta X · Issue #39 / Open Synthesis X · Issue #39](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/39)
+- [Revisión 1.2 · Issue #184 / Revision 1.2 · Issue #184](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/184)
 
 <!-- NEO_CROSS_REFERENCES_END -->

--- a/versiones/WEB4_NEOCORE_EVOLUCION_PUBLICA_ES_EN.md
+++ b/versiones/WEB4_NEOCORE_EVOLUCION_PUBLICA_ES_EN.md
@@ -7,6 +7,8 @@
 **Manifiesto relacionado / Related manifesto:** [X · WEB4™ · SistemaTrazable™](../manifiestos/07_web4_sistematrazable_ES_EN.md)  
 **Versión vigente de NEOCore™ / Current NEOCore™ version:** [resolver siempre desde `versiones/README.md` / always resolve from `versiones/README.md`](./README.md)
 
+[ES · Castellano](#es--castellano) · [EN · English](#en--english)
+
 ---
 
 # ES · Castellano

--- a/versiones/WEB4_NEOCORE_EVOLUCION_PUBLICA_ES_EN.md
+++ b/versiones/WEB4_NEOCORE_EVOLUCION_PUBLICA_ES_EN.md
@@ -1,0 +1,262 @@
+# WEB4™ ↔ NEOCore™ · evolución pública y regla de versionado
+# WEB4™ ↔ NEOCore™ · public evolution and versioning rule
+
+**Estado / Status:** Documento público de genealogía y navegación · no sustituye al registro canónico de versión / Public genealogy and navigation document · does not replace the canonical version registry  
+**Fecha / Date:** 2026-09-04  
+**Issue de revisión / Revision issue:** [#184](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/184)  
+**Manifiesto relacionado / Related manifesto:** [X · WEB4™ · SistemaTrazable™](../manifiestos/07_web4_sistematrazable_ES_EN.md)  
+**Versión vigente de NEOCore™ / Current NEOCore™ version:** [resolver siempre desde `versiones/README.md` / always resolve from `versiones/README.md`](./README.md)
+
+---
+
+# ES · Castellano
+
+## 1. Para qué existe este documento
+
+WEB4™ y NEOCore™ evolucionan relacionados, pero **no comparten un único número de versión**.
+
+```text
+NEOCORE_VERSION ≠ WEB4_VERSION
+```
+
+Este documento conserva una genealogía pública de alto nivel para explicar cómo se relacionan ambos sistemas sin convertir el Manifiesto X en un changelog ni exponer mecanismos privados innecesarios.
+
+La única fuente pública que determina qué versión de NEOCore™ está vigente es [`versiones/README.md`](./README.md). Cualquier número incluido aquí describe un **hito histórico material**, no una copia dinámica de `CURRENT_VERSION`.
+
+## 2. Regla de evolución
+
+La evolución pública se interpreta así:
+
+```text
+ESTADO HEREDADO
++ DELTA EXPLÍCITO
++ PROCEDENCIA / EVIDENCIA
++ RELACIONES AFECTADAS
++ CONTRASTE / PRUEBA CUANDO PROCEDA
++ FIJACIÓN COMPETENTE
+= NUEVO ESTADO TRAZABLE
+```
+
+Y conserva estas separaciones:
+
+```text
+DELTA ≠ CANON
+TRAZA ≠ VALIDACIÓN
+DRAFT / PENDIENTE-SAN ≠ APROBADO
+CURRENT_VERSION ≠ VERSION_OF_ORIGIN
+```
+
+Una versión nueva **no reescribe retroactivamente** lo que una versión anterior sabía, afirmaba o implementaba. La versión anterior conserva su contexto y puede ser reconstruida desde la genealogía Git, documentos de versión y trazas asociadas.
+
+## 3. Hitos públicos
+
+### 2026-08-06 · Manifiesto X 1.1
+
+La formulación fundacional de [WEB4™ · SistemaTrazable™](../manifiestos/07_web4_sistematrazable_ES_EN.md) fijó la idea de una capa pública relacional capaz de conservar identidad, función, estado, genealogía, relaciones, transformación y niveles de acceso.
+
+Ese texto era correcto como origen, pero deliberadamente breve.
+
+### 2026-08-26 · NEOCore™ 7.3 pasa a canon abierto
+
+La fase `7.3-CANDIDATE` queda como estado histórico cuando NEOCore™ 7.3 es promovido a canon abierto, canónico y reabrible. La evolución posterior hereda ese estado sin borrar la fase pre-canónica.
+
+Fuentes:
+
+- [Canon 7.3](../propuestas/sintesis-abierta/NEOCORE_7_3_CANON_ES_EN.md)
+- [Matriz 7.3 · Autosíntesis Recursiva](../propuestas/sintesis-abierta/NEOCORE_7_3_AUTOSINTESIS_RECURSIVA_ES_EN.md)
+
+### 2026-08-31 · NEOCore™ 7.3.3 integra la evolución modular WEB4™
+
+[NEOCore™ 7.3.3](./NEOCORE_7_3_3_ES_EN.md) fija como delta material la evolución modular verificada de WEB4™ disponible en ese momento y hace explícita su arquitectura social como red de conocimiento, creación y aporte trazable.
+
+Ese hito establece públicamente, entre otras cosas:
+
+- `NEOCORE_VERSION ≠ WEB4_VERSION`;
+- WEB4™ no es una colección de páginas independientes;
+- el nodo trazable, sus fuentes, relaciones y actividad material forman la unidad social de la red;
+- la existencia de una arquitectura o capacidad objetivo no equivale a capacidad funcional ya promovida;
+- la IA puede ampliar memoria, navegación, contraste y estructuración bajo responsabilidad humana;
+- la proyección pública efectiva requiere su propia verificación.
+
+### 2026-09-04 · Manifiesto X 1.2
+
+La revisión 1.2 amplía la formulación pública de WEB4™ para hacer visible lo que ya era estructuralmente cierto pero no estaba suficientemente explicado en la versión 1.1:
+
+- WEB4™ como proyección pública y operativa de un corpus humano–IA vivo;
+- corpus versionado, relacional, reabrible y autogestionado;
+- red viva **OFF-CHAIN** como modelo de referencia;
+- relación funcional de alto nivel con NEOCore™, SAN™, NAVE™, Leónidas™ y NeoCronos™;
+- arquitectura social basada en nodos y aportes trazables, no en popularidad;
+- separación entre arquitectura, estado verificable y proyección pública;
+- reconstrucción temporal y atribución humano–IA;
+- privacidad por capas e interoperabilidad/salida;
+- límites públicos de exposición de la arquitectura protegida.
+
+La revisión está trazada en [Issue #184](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/184) y permanece abierta a [Síntesis Abierta #39](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/39).
+
+## 4. Qué significa OFF-CHAIN aquí
+
+**OFF-CHAIN** no significa ausencia de evidencia ni opacidad.
+
+Significa que la identidad del corpus, la relación semántica, la genealogía, el estado de una síntesis, el reconocimiento de un aporte o la memoria del sistema **no dependen obligatoriamente de una cadena pública o blockchain para existir**.
+
+La evidencia puede apoyarse, según el objeto, en repositorios, commits, hashes, documentos, fuentes, registros, firmas, identificadores o pruebas externas. Lo importante es que la relación pueda conservar procedencia y reconstrucción suficiente.
+
+```text
+OFF-CHAIN ≠ SIN TRAZA
+OFF-CHAIN ≠ SIN VERIFICACIÓN
+OFF-CHAIN ≠ BLOCKCHAIN OBLIGATORIA
+```
+
+La implementación concreta y las mecánicas privadas de cálculo, ponderación, automatización o sincronización no se publican por defecto.
+
+## 5. Qué permanece protegido
+
+La transparencia pública debe permitir comprender y auditar **qué hace el sistema y qué evidencia deja**, sin convertir el repositorio público en un manual de clonación de toda su arquitectura interna.
+
+No forman parte de esta genealogía pública, salvo decisión expresa posterior:
+
+- reglas privadas de cálculo y ponderación;
+- heurísticas internas;
+- instrucciones de agentes y automatismos protegidos;
+- credenciales, secretos o configuraciones sensibles;
+- topología privada completa;
+- mecanismos de sincronización interna no necesarios para verificación pública;
+- datos personales o material restringido.
+
+## 6. Regla de lectura futura
+
+Para saber el estado vigente:
+
+1. consultar [`versiones/README.md`](./README.md);
+2. leer el documento específico de la versión cuando sea necesario;
+3. usar este documento para la genealogía pública WEB4™ ↔ NEOCore™;
+4. usar el [Manifiesto X](../manifiestos/07_web4_sistematrazable_ES_EN.md) para principios y arquitectura pública de alto nivel;
+5. usar Issues, auditorías y commits para reconstruir deltas concretos.
+
+---
+
+# EN · English
+
+## 1. Purpose of this document
+
+WEB4™ and NEOCore™ evolve in relation to each other, but **they do not share a single version number**.
+
+```text
+NEOCORE_VERSION ≠ WEB4_VERSION
+```
+
+This document preserves a high-level public genealogy explaining how both systems relate without turning Manifesto X into a changelog or unnecessarily exposing protected internal mechanics.
+
+The only public source that determines the current NEOCore™ version is [`versiones/README.md`](./README.md). Any number included here describes a **material historical milestone**, not a dynamic copy of `CURRENT_VERSION`.
+
+## 2. Evolution rule
+
+Public evolution is read as:
+
+```text
+INHERITED STATE
++ EXPLICIT DELTA
++ PROVENANCE / EVIDENCE
++ AFFECTED RELATIONS
++ CONTRAST / TESTING WHERE APPLICABLE
++ COMPETENT FIXATION
+= NEW TRACEABLE STATE
+```
+
+The following distinctions remain protected:
+
+```text
+DELTA ≠ CANON
+TRACE ≠ VALIDATION
+DRAFT / PENDING-SAN ≠ APPROVED
+CURRENT_VERSION ≠ VERSION_OF_ORIGIN
+```
+
+A new version **does not retroactively rewrite** what an earlier version knew, claimed or implemented. The earlier version retains its context and may be reconstructed through Git genealogy, version documents and associated traces.
+
+## 3. Public milestones
+
+### 2026-08-06 · Manifesto X 1.1
+
+The foundational wording of [WEB4™ · SistemaTrazable™](../manifiestos/07_web4_sistematrazable_ES_EN.md) fixed the idea of a public relational layer able to preserve identity, function, state, genealogy, relations, transformation and access levels.
+
+The text was correct as an origin, but deliberately brief.
+
+### 2026-08-26 · NEOCore™ 7.3 becomes open canon
+
+The `7.3-CANDIDATE` phase becomes historical state when NEOCore™ 7.3 is promoted to open, canonical and reopenable canon. Later evolution inherits that state without erasing the pre-canonical phase.
+
+Sources:
+
+- [7.3 Canon](../propuestas/sintesis-abierta/NEOCORE_7_3_CANON_ES_EN.md)
+- [7.3 Matrix · Recursive Self-Synthesis](../propuestas/sintesis-abierta/NEOCORE_7_3_AUTOSINTESIS_RECURSIVA_ES_EN.md)
+
+### 2026-08-31 · NEOCore™ 7.3.3 integrates WEB4™ modular evolution
+
+[NEOCore™ 7.3.3](./NEOCORE_7_3_3_ES_EN.md) fixes as a material delta the verified modular evolution of WEB4™ available at that point and makes explicit its social architecture as a network of knowledge, creation and traceable contribution.
+
+That milestone publicly establishes, among other things:
+
+- `NEOCORE_VERSION ≠ WEB4_VERSION`;
+- WEB4™ is not a collection of independent pages;
+- the traceable node, its sources, relations and material activity form the social unit of the network;
+- the existence of an architecture or target capability does not equal an already promoted functional capability;
+- AI may extend memory, navigation, contrast and structuring under human responsibility;
+- effective public projection requires its own verification.
+
+### 2026-09-04 · Manifesto X 1.2
+
+Revision 1.2 expands the public wording of WEB4™ to make visible what was already structurally true but insufficiently explained in version 1.1:
+
+- WEB4™ as the public and operational projection of a living human–AI corpus;
+- a versioned, relational, reopenable and self-managed corpus;
+- a living **OFF-CHAIN** network as the reference model;
+- high-level functional relation with NEOCore™, SAN™, NAVE™, Leónidas™ and NeoCronos™;
+- social architecture based on nodes and traceable contributions rather than popularity;
+- separation between architecture, verifiable state and public projection;
+- temporal reconstruction and human–AI attribution;
+- layered privacy and interoperability/exit;
+- public exposure limits for protected architecture.
+
+The revision is traced in [Issue #184](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/184) and remains open to [Open Synthesis #39](https://github.com/PedroAlhambra/Innova-n.org-NEOCORE-NEODIALECTICA-NEODIALECTIC/issues/39).
+
+## 4. What OFF-CHAIN means here
+
+**OFF-CHAIN** does not mean absence of evidence or opacity.
+
+It means that corpus identity, semantic relation, genealogy, synthesis state, contribution recognition or system memory **do not have to depend on a public chain or blockchain in order to exist**.
+
+Evidence may rely, according to the object, on repositories, commits, hashes, documents, sources, records, signatures, identifiers or external proofs. What matters is that the relation can preserve sufficient provenance and reconstructibility.
+
+```text
+OFF-CHAIN ≠ WITHOUT TRACE
+OFF-CHAIN ≠ WITHOUT VERIFICATION
+OFF-CHAIN ≠ MANDATORY BLOCKCHAIN
+```
+
+Concrete implementation and private mechanics for calculation, weighting, automation or synchronisation are not public by default.
+
+## 5. What remains protected
+
+Public transparency should allow others to understand and audit **what the system does and what evidence it leaves** without turning the public repository into a cloning manual for its whole internal architecture.
+
+The following are outside this public genealogy unless explicitly authorised later:
+
+- private calculation and weighting rules;
+- internal heuristics;
+- protected agent and automation instructions;
+- credentials, secrets or sensitive configuration;
+- the complete private topology;
+- internal synchronisation mechanisms unnecessary for public verification;
+- personal data or restricted material.
+
+## 6. Future reading rule
+
+To determine current state:
+
+1. consult [`versiones/README.md`](./README.md);
+2. read the version-specific document where needed;
+3. use this document for the public WEB4™ ↔ NEOCore™ genealogy;
+4. use [Manifesto X](../manifiestos/07_web4_sistematrazable_ES_EN.md) for high-level public principles and architecture;
+5. use Issues, audits and commits to reconstruct concrete deltas.


### PR DESCRIPTION
## Resumen

Implementa la revisión sustantiva acordada para el **Manifiesto X · WEB4™ · SistemaTrazable™**.

Closes #184
Related: #39
Baseline CI debt: #186

## Cambios

- eleva el manifiesto de **1.1 → 1.2** preservando la genealogía de la formulación fundacional;
- define WEB4™ como proyección pública y operativa de un corpus humano–IA vivo, versionado, relacional y reabrible;
- incorpora red viva **OFF-CHAIN** como modelo de referencia sin publicar mecánicas privadas innecesarias;
- enlaza la versión vigente de NEOCore™ desde `versiones/README.md`, sin hardcodear `CURRENT_VERSION`;
- explica `NEOCORE_VERSION ≠ WEB4_VERSION` y la evolución por herencia + delta + genealogía + reapertura;
- integra a alto nivel NEOCore™, SAN™, NAVE™, Leónidas™, NeoCronos™ y Mapa Relacional Vivo™;
- refuerza atribución humano–IA, privacidad por capas, interoperabilidad/salida y reconstrucción temporal;
- preserva la ontología Neo0™ / ONe Starkdr™ vigente;
- distingue arquitectura objetivo, capacidad implementada y proyección pública verificada;
- enlaza demostradores públicos KDP/IDEA y Spotify/DistroKid sin presentarlos como validación universal;
- sustituye la referencia dinámica obsoleta a «última síntesis LXXXI» por la frontera viva del índice canónico;
- crea `versiones/WEB4_NEOCORE_EVOLUCION_PUBLICA_ES_EN.md` para que el manifiesto no se convierta en changelog.

## Límites de exposición

La revisión publica capacidades, principios, contratos funcionales de alto nivel y rutas verificables. Mantiene fuera de la superficie pública reglas privadas de cálculo, ponderaciones, heurísticas, instrucciones de agentes, sincronización protegida, credenciales y topología interna innecesaria.

## Integridad del delta

PASS en el head final para:
- paridad ES/EN del contenido;
- enlaces Markdown;
- relaciones NEOCore™;
- referencias de versión vigente;
- ontología Neo0™ / ONe Starkdr™.

El selector ES/EN nuevo de `WEB4_NEOCORE_EVOLUCION_PUBLICA_ES_EN.md` fue corregido tras el primer run.

Los gates globales que siguen en FAIL corresponden a deuda preexistente fuera de estos dos ficheros: cuatro selectores ES/EN antiguos, registro/portal C-NAX-28 y crossrefs faltantes del Manifiesto I Neo0™. Se han aislado y trazado en #186; no se declara por ello CI global limpio.

## Integridad documental

- ES/EN simétrico.
- `DOCUMENTO ↔ ISSUE` hacia #39 y #184.
- Relaciones y navegación clicables preservadas/ampliadas en el Manifiesto X.
- No se modifica `CURRENT_VERSION` de NEOCore™ ni se declara una nueva versión del núcleo.
- Comparación con `main`: 2 ficheros, sin eliminaciones de ficheros; el manifiesto crece materialmente en lugar de reducirse.